### PR TITLE
fix(robots): 🐛 update robots rules based on environment

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -5,17 +5,17 @@ import { siteConfig } from "@/utils/siteConfig";
 export default function robots(): MetadataRoute.Robots {
 	return {
 		host: siteConfig.url,
-		// Allow all requests except for api
-		// rules: {
-		// 	allow: "/",
-		// 	disallow: "/api/",
-		// 	userAgent: "*",
-		// },
-		// Block all requests
-		rules: {
-			disallow: "/",
-			userAgent: "*",
-		},
+		rules:
+			process.env.NODE_ENV === "production"
+				? {
+						allow: "/",
+						disallow: "/api/",
+						userAgent: "*",
+					}
+				: {
+						disallow: "/",
+						userAgent: "*",
+					},
 		sitemap: `${siteConfig.url}/sitemap.xml`,
 	};
 }

--- a/src/utils/metadataUtils.ts
+++ b/src/utils/metadataUtils.ts
@@ -42,10 +42,16 @@ export const sharedMetadata = {
 	other: { "apple-mobile-web-app-capable": "yes" },
 	publisher: "Vercel",
 	referrer: "origin-when-cross-origin",
-	robots: {
-		follow: true,
-		index: true,
-	},
+	robots:
+		process.env.VERCEL_ENV === "production"
+			? {
+					follow: true,
+					index: true,
+				}
+			: {
+					follow: false,
+					index: false,
+				},
 } satisfies Partial<Metadata>;
 
 interface GeneratePageMetadataProps {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to next-ts-app-template! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #377
- [x] Steps in [CONTRIBUTING.md](https://github.com/timelessco/next-ts-app-template/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

This pull request includes changes to the `robots` rules configuration, making them environment-specific to handle requests differently based on the environment. The most important changes are in the `src/app/robots.ts` and `src/utils/metadataUtils.ts` files.

Environment-specific robots rules:

* [`src/app/robots.ts`](diffhunk://#diff-ed9ec6703690885f59a70b98dc1bf064161c8d9065092c565092143c211f04bbL8-R15): Updated the `robots` function to apply different rules for production and non-production environments. In production, the rules allow all requests except for `/api/`, whereas in non-production, all requests are disallowed.

* [`src/utils/metadataUtils.ts`](diffhunk://#diff-c6582b2bde71789671e6a32e51a42fa7fca3502be49398110268db0b85343be6L45-R53): Modified the `sharedMetadata` to set `robots` rules based on the `VERCEL_ENV` environment variable. In production, the rules allow following and indexing, while in non-production, these actions are disallowed.